### PR TITLE
feat(simulation): Add end of simulation summary and statistics

### DIFF
--- a/app/data/data.ts
+++ b/app/data/data.ts
@@ -13,6 +13,7 @@ export const initialParticipants: Participant[] = [
     timesDoingNothing: 0,
     cameraToggles: 0,
     participationRate: 0,
+    numberOfInteractions: 0,
     speakingStyle:
       'Friendly and collaborative, often asking questions to engage others',
     agentDescription:
@@ -27,6 +28,7 @@ export const initialParticipants: Participant[] = [
     timesDoingNothing: 0,
     cameraToggles: 0,
     participationRate: 0,
+    numberOfInteractions: 0,
     speakingStyle: 'Direct and analytical, focuses on practical solutions',
     agentDescription:
       'A pragmatic problem-solver who helps keep discussions on track',
@@ -40,6 +42,7 @@ export const initialParticipants: Participant[] = [
     timesDoingNothing: 0,
     cameraToggles: 0,
     participationRate: 0,
+    numberOfInteractions: 0,
     speakingStyle: 'Creative and enthusiastic, brings new perspectives',
     agentDescription:
       'An innovative thinker who excels at generating unique ideas',
@@ -53,6 +56,7 @@ export const initialParticipants: Participant[] = [
     timesDoingNothing: 0,
     cameraToggles: 0,
     participationRate: 0,
+    numberOfInteractions: 0,
     speakingStyle: 'Diplomatic and detail-oriented, helps build consensus',
     agentDescription:
       'A mediator who excels at finding common ground and synthesizing ideas',

--- a/app/data/data.ts
+++ b/app/data/data.ts
@@ -13,8 +13,10 @@ export const initialParticipants: Participant[] = [
     timesDoingNothing: 0,
     cameraToggles: 0,
     participationRate: 0,
-    speakingStyle: 'Friendly and collaborative, often asking questions to engage others',
-    agentDescription: 'A thoughtful team player who actively seeks to include everyone in the discussion'
+    speakingStyle:
+      'Friendly and collaborative, often asking questions to engage others',
+    agentDescription:
+      'A thoughtful team player who actively seeks to include everyone in the discussion',
   },
   {
     id: 2,
@@ -26,7 +28,8 @@ export const initialParticipants: Participant[] = [
     cameraToggles: 0,
     participationRate: 0,
     speakingStyle: 'Direct and analytical, focuses on practical solutions',
-    agentDescription: 'A pragmatic problem-solver who helps keep discussions on track'
+    agentDescription:
+      'A pragmatic problem-solver who helps keep discussions on track',
   },
   {
     id: 3,
@@ -38,7 +41,8 @@ export const initialParticipants: Participant[] = [
     cameraToggles: 0,
     participationRate: 0,
     speakingStyle: 'Creative and enthusiastic, brings new perspectives',
-    agentDescription: 'An innovative thinker who excels at generating unique ideas'
+    agentDescription:
+      'An innovative thinker who excels at generating unique ideas',
   },
   {
     id: 4,
@@ -50,39 +54,40 @@ export const initialParticipants: Participant[] = [
     cameraToggles: 0,
     participationRate: 0,
     speakingStyle: 'Diplomatic and detail-oriented, helps build consensus',
-    agentDescription: 'A mediator who excels at finding common ground and synthesizing ideas'
+    agentDescription:
+      'A mediator who excels at finding common ground and synthesizing ideas',
   },
 ]
 
 export const salvageItems = [
-  { id: 1, name: 'A sextant', emoji: '🧭', initialRank: 1 },
-  { id: 2, name: 'A shaving mirror', emoji: '🪞', initialRank: 2 },
+  { id: 1, name: 'A shaving mirror', emoji: '🪞', realRank: 1 },
   {
-    id: 3,
-    name: 'A quantity of mosquito netting',
-    emoji: '🦟',
-    initialRank: 3,
-  },
-  { id: 4, name: 'A 25-liter container of water', emoji: '💧', initialRank: 4 },
-  { id: 5, name: 'A case of army rations', emoji: '🥫', initialRank: 5 },
-  { id: 6, name: 'Maps of the Atlantic Ocean', emoji: '🗺️', initialRank: 6 },
-  { id: 7, name: 'A floating seat cushion', emoji: '💺', initialRank: 7 },
-  {
-    id: 8,
+    id: 2,
     name: 'A 10-liter can of oil/petrol mixture',
     emoji: '⛽',
-    initialRank: 8,
+    realRank: 2,
   },
-  { id: 9, name: 'A small transistor radio', emoji: '📻', initialRank: 9 },
+  { id: 3, name: 'A 25-liter container of water', emoji: '💧', realRank: 3 },
+  { id: 4, name: 'A case of army rations', emoji: '🥫', realRank: 4 },
   {
-    id: 10,
+    id: 5,
     name: '20 square feet of opaque plastic sheeting',
     emoji: '📦',
-    initialRank: 10,
+    realRank: 5,
   },
-  { id: 11, name: 'A can of shark repellent', emoji: '🦈', initialRank: 11 },
-  { id: 12, name: 'One bottle of 160 proof rum', emoji: '🥃', initialRank: 12 },
-  { id: 13, name: '15 feet of nylon rope', emoji: '🪢', initialRank: 13 },
-  { id: 14, name: '2 boxes of chocolate bars', emoji: '🍫', initialRank: 14 },
-  { id: 15, name: 'An ocean fishing kit & pole', emoji: '🎣', initialRank: 15 },
+  { id: 6, name: '2 boxes of chocolate bars', emoji: '🍫', realRank: 6 },
+  { id: 7, name: 'An ocean fishing kit & pole', emoji: '🎣', realRank: 7 },
+  { id: 8, name: '15 feet of nylon rope', emoji: '🪢', realRank: 8 },
+  { id: 9, name: 'A floating seat cushion', emoji: '💺', realRank: 9 },
+  { id: 10, name: 'A can of shark repellent', emoji: '🦈', realRank: 10 },
+  { id: 11, name: 'One bottle of 160 proof rum', emoji: '🥃', realRank: 11 },
+  { id: 12, name: 'A small transistor radio', emoji: '📻', realRank: 12 },
+  { id: 13, name: 'Maps of the Atlantic Ocean', emoji: '🗺️', realRank: 13 },
+  {
+    id: 14,
+    name: 'A quantity of mosquito netting',
+    emoji: '🦟',
+    realRank: 14,
+  },
+  { id: 15, name: 'A sextant', emoji: '🧭', realRank: 15 },
 ]

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -582,7 +582,6 @@ export default function BreakoutRoomSimulator() {
             }
           })}
         totalTurns={currentStep}
-        totalScore={calculateTaskScore()}
         simulationType={selectedScenario?.id || 'baseline'}
       />
       <Toaster />

--- a/app/simulations/components/columns.tsx
+++ b/app/simulations/components/columns.tsx
@@ -125,7 +125,7 @@ export const columns: ColumnDef<Simulation>[] = [
       const score: number | null = row.getValue('taskScore')
       return (
         <div className='text-center'>
-          {score !== null ? `${score.toFixed(2)}%` : 'N/A'}
+          {score !== null ? Math.round(score) : 'N/A'}
         </div>
       )
     },
@@ -150,7 +150,9 @@ export const columns: ColumnDef<Simulation>[] = [
       const participation: number | undefined = row.getValue('avgParticipation')
       return (
         <div className='text-center'>
-          {participation !== undefined ? `${participation.toFixed(2)}%` : 'N/A'}
+          {participation !== undefined
+            ? `${Math.round(participation)}%`
+            : 'N/A'}
         </div>
       )
     },

--- a/app/types/types.ts
+++ b/app/types/types.ts
@@ -12,6 +12,7 @@ export type Participant = {
   participationRate: number
   speakingStyle: string
   agentDescription: string
+  numberOfInteractions: number
 }
 
 /**
@@ -105,4 +106,12 @@ export type ParticipantInterestScore = {
   participantId: number
   score: number
   reasoning: string
+}
+
+/**
+ * Represents an input to the simulation.
+ */
+export interface SimulationInput {
+  // ... existing properties ...
+  recentChanges?: boolean[]
 }

--- a/components/SimulationControls.tsx
+++ b/components/SimulationControls.tsx
@@ -2,7 +2,7 @@ import { MAX_SIMULATION_TURNS } from '@/app/constants/constants'
 import { Scenario } from '@/components/ScenarioSelector'
 import { Button } from '@/components/ui/button'
 import { SimulationTurn } from '@/lib/services/simulation-service'
-import { Loader2, Pause, Play, SkipForward, Square } from 'lucide-react'
+import { Loader2, Pause, Play, Save, SkipForward } from 'lucide-react'
 
 interface SimulationControlsProps {
   onNextStep: () => void
@@ -15,6 +15,7 @@ interface SimulationControlsProps {
   loadingButton: 'next' | 'play' | 'end' | null
   simulationTurns: SimulationTurn[]
   selectedScenario: Scenario | null
+  simulationEnded?: boolean
 }
 
 export function SimulationControls({
@@ -28,13 +29,16 @@ export function SimulationControls({
   loadingButton,
   simulationTurns,
   selectedScenario,
+  simulationEnded = false,
 }: SimulationControlsProps) {
   return (
     <div className='flex items-center justify-between gap-6 w-full'>
       <div className='flex items-center gap-3'>
         <Button
           onClick={onNextStep}
-          disabled={isLoading || isPlaying || !selectedScenario}
+          disabled={
+            isLoading || isPlaying || !selectedScenario || simulationEnded
+          }
           className='w-28 h-9'
           variant={'ghost'}
         >
@@ -59,7 +63,9 @@ export function SimulationControls({
         <Button
           onClick={onPlayPauseSimulation}
           disabled={
-            !selectedScenario || (!isPlaying && loadingButton === 'next')
+            !selectedScenario ||
+            (!isPlaying && loadingButton === 'next') ||
+            simulationEnded
           }
           className='w-28 h-9'
           variant='ghost'
@@ -94,7 +100,12 @@ export function SimulationControls({
 
       <Button
         onClick={onEndSimulation}
-        disabled={isLoading || !hasStarted || simulationTurns.length === 0}
+        disabled={
+          isLoading ||
+          !hasStarted ||
+          simulationTurns.length === 0 ||
+          simulationEnded
+        }
         variant='ghost'
         className='w-28 h-9'
       >
@@ -105,7 +116,7 @@ export function SimulationControls({
           </>
         ) : (
           <>
-            <Square className='mr-2 h-4 w-4' />
+            <Save className='mr-2 h-4 w-4' />
             End
           </>
         )}

--- a/components/SimulationControls.tsx
+++ b/components/SimulationControls.tsx
@@ -2,7 +2,7 @@ import { MAX_SIMULATION_TURNS } from '@/app/constants/constants'
 import { Scenario } from '@/components/ScenarioSelector'
 import { Button } from '@/components/ui/button'
 import { SimulationTurn } from '@/lib/services/simulation-service'
-import { Loader2, Pause, Play, Save, SkipForward } from 'lucide-react'
+import { Loader2, Pause, Play, SkipForward, Square } from 'lucide-react'
 
 interface SimulationControlsProps {
   onNextStep: () => void
@@ -12,7 +12,7 @@ interface SimulationControlsProps {
   isPlaying: boolean
   hasStarted: boolean
   currentStep: number
-  loadingButton: 'next' | 'play' | 'save' | null
+  loadingButton: 'next' | 'play' | 'end' | null
   simulationTurns: SimulationTurn[]
   selectedScenario: Scenario | null
 }
@@ -94,21 +94,19 @@ export function SimulationControls({
 
       <Button
         onClick={onEndSimulation}
-        disabled={
-          isLoading || !hasStarted || simulationTurns.length === 0 || isPlaying
-        }
+        disabled={isLoading || !hasStarted || simulationTurns.length === 0}
         variant='ghost'
         className='w-28 h-9'
       >
-        {loadingButton === 'save' ? (
+        {loadingButton === 'end' ? (
           <>
             <Loader2 className='mr-2 h-4 w-4 animate-spin' />
             Wait...
           </>
         ) : (
           <>
-            <Save className='mr-2 h-4 w-4' />
-            Save
+            <Square className='mr-2 h-4 w-4' />
+            End
           </>
         )}
       </Button>

--- a/components/SimulationSummaryDialog.tsx
+++ b/components/SimulationSummaryDialog.tsx
@@ -43,11 +43,6 @@ type SimulationSummaryDialogProps = {
   simulationType: 'baseline' | 'leadership' | 'social' | 'gamification'
 }
 
-type SalvageItem = {
-  name: string
-  emoji: string
-}
-
 function getTypeStyles(
   type: 'baseline' | 'leadership' | 'social' | 'gamification'
 ): string {

--- a/components/SimulationSummaryDialog.tsx
+++ b/components/SimulationSummaryDialog.tsx
@@ -1,0 +1,251 @@
+import { salvageItems } from '@/app/data/data'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+type Participant = {
+  id: number
+  name: string
+  avatar: string
+  wordsSpoken: number
+  timesDoingNothing: number
+  cameraToggles: number
+  participationRate: number
+  numberOfInteractions: number
+}
+
+type SimulationSummaryDialogProps = {
+  isOpen: boolean
+  onClose: () => void
+  participants: Participant[]
+  finalRanking: {
+    name: string
+    emoji: string
+    rank: number
+    realRank: number
+  }[]
+  totalTurns: number
+  totalScore: number
+}
+
+type SalvageItem = {
+  name: string
+  emoji: string
+}
+
+export function SimulationSummaryDialog({
+  isOpen,
+  onClose,
+  participants,
+  finalRanking,
+  totalTurns,
+  totalScore,
+}: SimulationSummaryDialogProps) {
+  const averageWordsSpoken =
+    participants.reduce((sum, p) => sum + p.wordsSpoken, 0) /
+    participants.length
+  const averageParticipationRate =
+    participants.reduce((sum, p) => sum + p.participationRate, 0) /
+    participants.length
+
+  const rankingWithDiff = Array(15)
+    .fill(null)
+    .map((_, index) => {
+      const correctItem = salvageItems[index]
+      const rankedPosition = finalRanking.find(
+        (item) => item.name === correctItem.name
+      )
+
+      if (rankedPosition && rankedPosition.rank > 0) {
+        return {
+          name: correctItem.name,
+          emoji: correctItem.emoji,
+          rank: rankedPosition.rank,
+          realRank: correctItem.realRank,
+          diff: Math.abs(rankedPosition.rank - correctItem.realRank),
+        }
+      } else {
+        return {
+          name: correctItem.name,
+          emoji: correctItem.emoji,
+          rank: 0, // Will be displayed as '-'
+          realRank: correctItem.realRank,
+          diff: correctItem.realRank,
+        }
+      }
+    })
+    .sort((a, b) => {
+      // Put items with rank 0 (unranked) at the bottom
+      if (a.rank === 0 && b.rank === 0) return 0
+      if (a.rank === 0) return 1
+      if (b.rank === 0) return -1
+      // Sort ranked items by their current rank
+      return a.rank - b.rank
+    })
+
+  const totalDiff = rankingWithDiff.reduce((sum, item) => sum + item.diff, 0)
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className='max-w-4xl h-[90vh] p-0 flex flex-col'>
+        <ScrollArea className='flex-grow'>
+          <div className='p-6 space-y-6'>
+            <DialogHeader>
+              <DialogTitle>Simulation Summary</DialogTitle>
+              <DialogDescription>
+                Overview of the icebreaker activity results after {totalTurns}{' '}
+                turns
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4'>
+              <Card>
+                <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
+                  <CardTitle className='text-sm font-medium'>
+                    Total Score
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className='text-2xl font-bold'>{totalScore}</div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
+                  <CardTitle className='text-sm font-medium'>
+                    Average Words Spoken
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className='text-2xl font-bold'>
+                    {averageWordsSpoken.toFixed(1)}
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
+                  <CardTitle className='text-sm font-medium'>
+                    Avg. Participation
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className='text-2xl font-bold'>
+                    {(averageParticipationRate * 100).toFixed(1)}%
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
+                  <CardTitle className='text-sm font-medium'>
+                    Total Turns
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className='text-2xl font-bold'>{totalTurns}</div>
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Participant Statistics</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Avatar</TableHead>
+                      <TableHead>Name</TableHead>
+                      <TableHead>Words Spoken</TableHead>
+                      <TableHead>Number of Interactions</TableHead>
+                      <TableHead>Times Inactive</TableHead>
+                      <TableHead>Camera Toggles</TableHead>
+                      <TableHead>Participation Rate</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {participants.map((participant) => (
+                      <TableRow key={participant.id}>
+                        <TableCell>
+                          <Avatar>
+                            <AvatarImage
+                              src={participant.avatar}
+                              alt={`${participant.name}'s avatar`}
+                            />
+                            <AvatarFallback>
+                              {participant.name[0]}
+                            </AvatarFallback>
+                          </Avatar>
+                        </TableCell>
+                        <TableCell>{participant.name}</TableCell>
+                        <TableCell>{participant.wordsSpoken}</TableCell>
+                        <TableCell>
+                          {participant.numberOfInteractions}
+                        </TableCell>
+                        <TableCell>{participant.timesDoingNothing}</TableCell>
+                        <TableCell>{participant.cameraToggles}</TableCell>
+                        <TableCell>
+                          {(participant.participationRate * 100).toFixed(1)}%
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Final Item Ranking</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Item</TableHead>
+                      <TableHead>Current Rank</TableHead>
+                      <TableHead>Real Rank</TableHead>
+                      <TableHead>Diff</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {rankingWithDiff.map((item) => (
+                      <TableRow key={item.rank}>
+                        <TableCell>{`${item.emoji} ${item.name}`}</TableCell>
+                        <TableCell>
+                          {item.rank === 0 ? '-' : item.rank}
+                        </TableCell>
+                        <TableCell>{item.realRank}</TableCell>
+                        <TableCell>{item.diff}</TableCell>
+                      </TableRow>
+                    ))}
+                    <TableRow>
+                      <TableCell colSpan={3} className='font-bold'>
+                        Total Difference
+                      </TableCell>
+                      <TableCell className='font-bold'>{totalDiff}</TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/SimulationSummaryDialog.tsx
+++ b/components/SimulationSummaryDialog.tsx
@@ -39,7 +39,6 @@ type SimulationSummaryDialogProps = {
     realRank: number
   }[]
   totalTurns: number
-  totalScore: number
   simulationType: 'baseline' | 'leadership' | 'social' | 'gamification'
 }
 
@@ -66,7 +65,6 @@ export function SimulationSummaryDialog({
   participants,
   finalRanking,
   totalTurns,
-  totalScore,
   simulationType,
 }: SimulationSummaryDialogProps) {
   const averageWordsSpoken =

--- a/components/SimulationSummaryDialog.tsx
+++ b/components/SimulationSummaryDialog.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
@@ -41,11 +40,29 @@ type SimulationSummaryDialogProps = {
   }[]
   totalTurns: number
   totalScore: number
+  simulationType: 'baseline' | 'leadership' | 'social' | 'gamification'
 }
 
 type SalvageItem = {
   name: string
   emoji: string
+}
+
+function getTypeStyles(
+  type: 'baseline' | 'leadership' | 'social' | 'gamification'
+): string {
+  switch (type) {
+    case 'baseline':
+      return 'bg-zinc-100 text-zinc-800'
+    case 'leadership':
+      return 'bg-blue-100 text-blue-800'
+    case 'social':
+      return 'bg-purple-100 text-purple-800'
+    case 'gamification':
+      return 'bg-green-100 text-green-800'
+    default:
+      return 'bg-gray-100 text-gray-800'
+  }
 }
 
 export function SimulationSummaryDialog({
@@ -55,6 +72,7 @@ export function SimulationSummaryDialog({
   finalRanking,
   totalTurns,
   totalScore,
+  simulationType,
 }: SimulationSummaryDialogProps) {
   const averageWordsSpoken =
     participants.reduce((sum, p) => sum + p.wordsSpoken, 0) /
@@ -105,12 +123,20 @@ export function SimulationSummaryDialog({
       <DialogContent className='max-w-4xl h-[90vh] p-0 flex flex-col'>
         <ScrollArea className='flex-grow'>
           <div className='p-6 space-y-6'>
-            <DialogHeader>
-              <DialogTitle>Simulation Summary</DialogTitle>
-              <DialogDescription>
-                Overview of the icebreaker activity results after {totalTurns}{' '}
-                turns
-              </DialogDescription>
+            <DialogHeader className='flex flex-row items-center'>
+              <div className='flex items-center gap-3'>
+                <DialogTitle className='text-xl font-semibold'>
+                  Simulation Summary
+                </DialogTitle>
+                <div
+                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getTypeStyles(
+                    simulationType
+                  )}`}
+                >
+                  {simulationType.charAt(0).toUpperCase() +
+                    simulationType.slice(1)}
+                </div>
+              </div>
             </DialogHeader>
 
             <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4'>
@@ -121,7 +147,7 @@ export function SimulationSummaryDialog({
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className='text-2xl font-bold'>{totalScore}</div>
+                  <div className='text-2xl font-bold'>{totalDiff}</div>
                 </CardContent>
               </Card>
               <Card>
@@ -181,10 +207,11 @@ export function SimulationSummaryDialog({
                     {participants.map((participant) => (
                       <TableRow key={participant.id}>
                         <TableCell>
-                          <Avatar>
+                          <Avatar className='h-8 w-8'>
                             <AvatarImage
                               src={participant.avatar}
                               alt={`${participant.name}'s avatar`}
+                              className='object-cover'
                             />
                             <AvatarFallback>
                               {participant.name[0]}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/lib/services/simulation-service.ts
+++ b/lib/services/simulation-service.ts
@@ -17,18 +17,21 @@ export type SaveSimulationParams = {
   simulationType: 'baseline' | 'leadership' | 'social' | 'gamification'
   participants: Participant[]
   turns: SimulationTurn[]
+  taskScore: number
 }
 
 export async function saveSimulation({
   simulationType,
   participants,
   turns,
+  taskScore,
 }: SaveSimulationParams) {
   return await prisma.$transaction(async (tx) => {
     const simulation = await tx.simulation.create({
       data: {
         simulationType,
         totalTurns: turns.length,
+        taskScore,
       },
     })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@prisma/client": "^6.0.0",
         "@radix-ui/react-avatar": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-progress": "^1.1.0",
         "@radix-ui/react-scroll-area": "^1.2.0",
@@ -707,6 +708,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz",
+      "integrity": "sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@prisma/client": "^6.0.0",
     "@radix-ui/react-avatar": "^1.1.1",
+    "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-scroll-area": "^1.2.0",


### PR DESCRIPTION
# Description
This PR introduces a comprehensive end-of-simulation experience, including a detailed summary dialog and improved statistics tracking.

## Key Changes
- Added new SimulationSummaryDialog component showing final statistics and rankings
- Implemented correct task scoring and ranking comparison system
- Enhanced participant statistics tracking (interactions, participation rates)
- Added simulation auto-end conditions based on inactivity or max turns
- Fixed column types and data display in simulation history table
- Improved simulation state management and data persistence

## Technical Details
- Created new `SimulationSummaryDialog` component with statistical breakdowns
- Added real rank tracking for salvage items to compare against user rankings
- Implemented scoring system based on ranking differences
- Added dialogue history numbering and tracking of recent changes
- Enhanced simulation end conditions with proper state management
- Fixed type issues in simulation table columns
- Added proper data saving functionality with correct score calculations

## UI Improvements
- New end-of-simulation modal with detailed statistics
- Enhanced ranking display showing differences from correct answers
- Improved participant statistics visualization
- Better formatted numbers in simulation history table
- Added proper simulation type badges and styling